### PR TITLE
feat(ci): add ARM64 support to build and release pipelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /gflows
 /c.out
 /gflows-darwin-amd64
+/gflows-darwin-arm64
 /gflows-linux-amd64
+/gflows-linux-arm64
 /node_modules

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,10 @@ LDFLAGS=-ldflags="-buildid= -X 'github.com/jbrunton/gflows/cmd.Version=${version
 go-build-release:
 	@test -n "$(version)" || (echo '$$version required' && exit 1)
 	export CGO_ENABLED=0
-	GOOS=darwin GOARCH=amd64 go build ${LDFLAGS} -trimpath -o gflows-darwin-amd64
-	GOOS=linux GOARCH=amd64 go build ${LDFLAGS} -trimpath -o gflows-linux-amd64
+	GOOS=darwin GOARCH=amd64  go build ${LDFLAGS} -trimpath -o gflows-darwin-amd64
+	GOOS=darwin GOARCH=arm64  go build ${LDFLAGS} -trimpath -o gflows-darwin-arm64
+	GOOS=linux  GOARCH=amd64  go build ${LDFLAGS} -trimpath -o gflows-linux-amd64
+	GOOS=linux  GOARCH=arm64  go build ${LDFLAGS} -trimpath -o gflows-linux-arm64
 
 compile: statik go-build
 


### PR DESCRIPTION
# Description:
This PR extends both our CI build workflow and the Makefile release process to produce and publish ARM64 binaries alongside the existing AMD64 artifacts. With these changes, users on ARM-based systems (e.g. Apple Silicon, ARM64 Linux) will be able to download pre-built gflows executables without compiling from source.